### PR TITLE
Add created and modified dates to View Entry screen

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/ui/view/ViewEntryActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/view/ViewEntryActivity.kt
@@ -19,6 +19,7 @@ import com.jksalcedo.passvault.data.PasswordEntry
 import com.jksalcedo.passvault.databinding.ActivityViewEntryBinding
 import com.jksalcedo.passvault.ui.addedit.AddEditActivity
 import com.jksalcedo.passvault.utils.Utility
+import com.jksalcedo.passvault.utils.Utility.formatTime
 import com.jksalcedo.passvault.viewmodel.PasswordViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -61,6 +62,8 @@ class ViewEntryActivity : AppCompatActivity() {
         val passwordCipher = intent.getStringExtra(EXTRA_PASSWORD_CIPHER)
         val passwordIv = intent.getStringExtra(EXTRA_PASSWORD_IV)
         val notes = intent.getStringExtra(EXTRA_NOTES)
+        val createdAt = intent.getLongExtra(EXTRA_CREATED_AT, -1)
+        val updatedAt = intent.getLongExtra(EXTRA_UPDATED_AT, -1)
 
         viewModel = ViewModelProvider(this)[PasswordViewModel::class.java]
 
@@ -76,7 +79,9 @@ class ViewEntryActivity : AppCompatActivity() {
             username = username,
             passwordCipher = passwordCipher,
             passwordIv = passwordIv,
-            notes = notes
+            notes = notes,
+            createdAt = createdAt,
+            updatedAt = updatedAt
         )
 
         // Decrypt using Encryption
@@ -92,6 +97,8 @@ class ViewEntryActivity : AppCompatActivity() {
         binding.tvUsername.text = username.orEmpty()
         binding.tvPassword.text = MASKED_PASSWORD
         binding.tvNotes.text = notes.orEmpty()
+        binding.tvMetadata.text =
+            "Created: ${createdAt.formatTime()} - Modified: ${updatedAt.formatTime()}"
 
         binding.btnCopyUsername.setOnClickListener {
             if (username?.isNotEmpty() == true) {
@@ -179,6 +186,8 @@ class ViewEntryActivity : AppCompatActivity() {
         const val EXTRA_PASSWORD_CIPHER = "extra_password_cipher"
         const val EXTRA_PASSWORD_IV = "extra_password_iv"
         const val EXTRA_NOTES = "extra_notes"
+        const val EXTRA_CREATED_AT = "created_at"
+        const val EXTRA_UPDATED_AT = "updated_at"
 
         private const val MASKED_PASSWORD = "••••••••"
 
@@ -190,6 +199,8 @@ class ViewEntryActivity : AppCompatActivity() {
                 putExtra(EXTRA_PASSWORD_CIPHER, entry.passwordCipher)
                 putExtra(EXTRA_PASSWORD_IV, entry.passwordIv)
                 putExtra(EXTRA_NOTES, entry.notes)
+                putExtra(EXTRA_CREATED_AT, entry.createdAt)
+                putExtra(EXTRA_UPDATED_AT, entry.updatedAt)
             }
         }
     }

--- a/app/src/main/java/com/jksalcedo/passvault/utils/Utility.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/utils/Utility.kt
@@ -11,6 +11,9 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 object Utility {
@@ -50,5 +53,10 @@ object Utility {
             bytes < 1024 * 1024 -> String.format(Locale.getDefault(), "%.2f KB", bytes / 1024.0)
             else -> String.format(Locale.getDefault(), "%.2f MB", bytes / (1024.0 * 1024.0))
         }
+    }
+
+    fun Long.formatTime(zoneId: ZoneId = ZoneId.systemDefault()): String = this.let {
+        val formatter = DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH)
+        return Instant.ofEpochMilli(it).atZone(zoneId).format(formatter)
     }
 }

--- a/app/src/test/java/com/jksalcedo/passvault/utils/UtilityTest.kt
+++ b/app/src/test/java/com/jksalcedo/passvault/utils/UtilityTest.kt
@@ -9,6 +9,7 @@ import com.jksalcedo.passvault.data.AppDatabase
 import com.jksalcedo.passvault.data.PasswordDao
 import com.jksalcedo.passvault.data.PasswordEntry
 import com.jksalcedo.passvault.getOrAwaitValue
+import com.jksalcedo.passvault.utils.Utility.formatTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -18,11 +19,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class UtilityTest {
+
+    private val utc = ZoneId.of("UTC")
 
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -116,4 +121,44 @@ class UtilityTest {
             )
         )
     }
+
+    @Test
+    fun `formatTime with known timestamp`() {
+        val zonedDateTime = ZonedDateTime.of(2025, 11, 8, 10, 30, 0, 0, utc)
+        val timestampInMillis = zonedDateTime.toInstant().toEpochMilli() // This gives us our Long
+
+        val formattedDate = timestampInMillis.formatTime(zoneId = utc)
+
+        assertThat(formattedDate).isEqualTo("Nov 08 2025")
+    }
+
+    @Test
+    fun `formatTime with epoch Jan 01 1970`() {
+        val epochTimestamp = 0L
+
+        val formattedDate = epochTimestamp.formatTime(zoneId = utc)
+
+        assertThat(formattedDate).isEqualTo("Jan 01 1970")
+    }
+
+    @Test
+    fun `formatTime with pre-epoch timestamp`() {
+        val zonedDateTime = ZonedDateTime.of(1969, 12, 25, 18, 0, 0, 0, utc)
+        val preEpochTimestamp = zonedDateTime.toInstant().toEpochMilli()
+
+        val formattedDate = preEpochTimestamp.formatTime(zoneId = utc)
+
+        assertThat(formattedDate).isEqualTo("Dec 25 1969")
+    }
+
+    @Test
+    fun `formatTime with epoch timestamp in different timezone`() {
+        val epochTimestamp = 0L
+        val newYorkZone = ZoneId.of("America/New_York")
+
+        val formattedDate = epochTimestamp.formatTime(zoneId = newYorkZone)
+
+        assertThat(formattedDate).isEqualTo("Dec 31 1969")
+    }
+
 }


### PR DESCRIPTION
This commit introduces the display of creation and modification timestamps on the "View Entry" screen.

**Changes:**

-   **`ViewEntryActivity.kt`**:
    -   Now retrieves `createdAt` and `updatedAt` timestamps from the intent extras.
    -   Displays these timestamps in a formatted string (e.g., "Created: Nov 08 2025 - Modified: Nov 08 2025").

-   **`Utility.kt`**:
    -   Added a `formatTime` extension function for `Long` to format epoch milliseconds into a "MMM dd yyyy" date string.

-   **`UtilityTest.kt`**:
    -   Added unit tests for the new `formatTime` function to verify its correctness across different timestamps and timezones.