### PR TITLE
Enable password visibility toggle for passkey/PIN fields

### DIFF
--- a/app/src/main/res/layout/dialog_passkey.xml
+++ b/app/src/main/res/layout/dialog_passkey.xml
@@ -14,7 +14,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_max="400dp">
+        app:layout_constraintWidth_max="400dp"
+        app:passwordToggleEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etPasskey"
@@ -34,7 +35,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/til1"
-        app:layout_constraintWidth_max="400dp">
+        app:layout_constraintWidth_max="400dp"
+        app:passwordToggleEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etConfirmPasskey"

--- a/app/src/main/res/layout/dialog_set_pin.xml
+++ b/app/src/main/res/layout/dialog_set_pin.xml
@@ -25,7 +25,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tvTitle"
-        app:layout_constraintWidth_max="400dp">
+        app:layout_constraintWidth_max="400dp"
+        app:passwordToggleEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etNewPin"
@@ -45,7 +46,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/til1"
-        app:layout_constraintWidth_max="400dp">
+        app:layout_constraintWidth_max="400dp"
+        app:passwordToggleEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etConfirmPin"


### PR DESCRIPTION
Added a password visibility toggle to the input fields in the "Set Passkey" and "Set PIN" dialogs, allowing users to show or hide their input. This improves usability by making it easier to verify the entered passkey or PIN.