### PR TITLE
feat(security): Disable automatic backup and data extraction

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,9 +7,7 @@
 
 
     <application
-        android:allowBackup="true"
-        android:dataExtractionRules="@xml/data_extraction_rules"
-        android:fullBackupContent="@xml/backup_rules"
+        android:allowBackup="false"
         android:icon="@drawable/ic_icon"
         android:label="@string/app_name"
         android:roundIcon="@drawable/ic_icon_rounded"


### PR DESCRIPTION
This commit enhances security by disabling the `allowBackup` feature in the `AndroidManifest.xml`.

The `android:allowBackup` attribute has been set to `false`. Consequently, the related `android:dataExtractionRules` and `android:fullBackupContent` attributes have been removed as they are no longer necessary. This change prevents automatic backups of application data to Google Drive, which is a recommended security practice to protect sensitive information.