### PR TITLE
Refactor ViewEntryActivity to use Parcelable Entry

### DIFF
--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -3,6 +3,7 @@ PassVault is a secure, lightweight, and 100% offline password manager for Androi
 It requests no internet permissions, so your data never leaves your device.
 
 FEATURES:
+
 - Secure Authentication: Access your vault using a PIN or Biometric (fingerprint) login.
 - Encrypted Storage: All passwords are encrypted at rest using AES-256 and stored securely in a local Room database.
 - 100% Offline-First: The app is fully functional without an internet connection.


### PR DESCRIPTION
This commit refactors `ViewEntryActivity` to receive a single `PasswordEntry` object as a Parcelable extra in the Intent, rather than multiple individual extras for each field.

**Key Changes:**
- **Intent Handling:** Replaced multiple `putExtra` calls (`EXTRA_ID`, `EXTRA_TITLE`, etc.) with a single `putExtra(EXTRA_ENTRY, entry)`.
- **Data Retrieval:** Updated the activity to retrieve the `PasswordEntry` object, handling different Android versions (TIRAMISU and above).
- **FAB Logic:** Consolidated the `expandFab()` and `collapseFab()` methods into a single `setFabVisibility(expanded: Boolean)` method to reduce code duplication.
- **Code Cleanup:** Improved null safety checks and simplified variable declarations.
- **UI:** Added a toolbar with a back button for improved navigation.