### PR TITLE
feat: Add BackupWorker for automatic data backup

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/workers/BackupWorker.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/workers/BackupWorker.kt
@@ -1,0 +1,80 @@
+package com.jksalcedo.passvault.workers
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.jksalcedo.passvault.repositories.PasswordRepository
+import com.jksalcedo.passvault.repositories.PreferenceRepository
+import com.jksalcedo.passvault.utils.Utility
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class BackupWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+    private val passwordRepository: PasswordRepository,
+    private val preferenceRepository: PreferenceRepository
+) : CoroutineWorker(appContext, workerParams) {
+
+    companion object {
+        const val TAG = "BackupWorker"
+    }
+
+    @Suppress("unused")
+    constructor(appContext: Context, workerParams: WorkerParameters) : this(
+        appContext,
+        workerParams,
+        PasswordRepository(appContext),
+        PreferenceRepository(appContext)
+    )
+
+    override suspend fun doWork(): Result {
+        return try {
+            withContext(Dispatchers.IO) {
+                Log.d(TAG, "Auto backup started.")
+
+                //Get all password entries
+                val entries = passwordRepository.getAllEntries()
+                if (entries.isEmpty()) {
+                    Log.d(TAG, "No data to back up. Skipping.")
+                    return@withContext Result.success()
+                }
+
+                val format = preferenceRepository.getExportFormat()
+                // val encrypt = preferenceRepository.getEncryptBackups()
+
+                // Serialize data
+                val data = when (format.uppercase()) {
+                    "JSON" -> Utility.serializeEntries(entries, format = format)
+                    "CSV" -> Utility.serializeEntries(entries, format = format)
+                    else -> Utility.serializeEntries(entries, "json") // Default to JSON
+                }
+
+                // Create the backup file
+                val backupsDir = File(applicationContext.getExternalFilesDir(null), "backups")
+                if (!backupsDir.exists()) {
+                    backupsDir.mkdirs()
+                }
+                val timestamp =
+                    SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+                val fileName = "passvault_backup_$timestamp.${format.lowercase()}"
+                val backupFile = File(backupsDir, fileName)
+
+                // Write data to the file
+                backupFile.writeText(data)
+
+                preferenceRepository.updateLastBackupTime()
+
+                Result.success()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Backup failed", e)
+            Result.failure()
+        }
+    }
+}

--- a/app/src/test/java/com/jksalcedo/passvault/workers/BackupWorkerTest.kt
+++ b/app/src/test/java/com/jksalcedo/passvault/workers/BackupWorkerTest.kt
@@ -1,0 +1,114 @@
+package com.jksalcedo.passvault.workers
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.jksalcedo.passvault.data.PasswordEntry
+import com.jksalcedo.passvault.repositories.PasswordRepository
+import com.jksalcedo.passvault.repositories.PreferenceRepository
+import com.jksalcedo.passvault.utils.Utility
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.Date
+
+class BackupWorkerTest {
+
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @JvmField
+    @Rule
+    var tempFolder = TemporaryFolder()
+
+    private lateinit var context: Context
+    private lateinit var mockPasswordRepo: PasswordRepository
+    private lateinit var mockPreferenceRepo: PreferenceRepository
+    private lateinit var backupsDir: File
+
+    @Before
+    fun setup() {
+        context = mockk(relaxed = true)
+        mockPasswordRepo = mockk()
+        mockPreferenceRepo = mockk()
+
+        // Set up the file directory
+        backupsDir = tempFolder.newFolder("backups")
+        every { context.getExternalFilesDir(null) } returns tempFolder.root
+
+        // Mock the Utility object
+        mockkObject(Utility)
+        every { Utility.serializeEntries(any(), any()) } returns "{\"key\":\"dummy_json\"}"
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `doWork returns Success when entries exist`() = runBlocking {
+        val fakeEntries = listOf(
+            PasswordEntry(1, "Test", "user", "pass", "iv1", "notes1", Date().time),
+        )
+        coEvery { mockPasswordRepo.getAllEntries() } returns fakeEntries
+        coEvery { mockPreferenceRepo.getExportFormat() } returns "json"
+        coEvery { mockPreferenceRepo.updateLastBackupTime() } returns Unit
+
+        val worker = TestListenableWorkerBuilder<BackupWorker>(context)
+            .setWorkerFactory(TestWorkerFactory(mockPasswordRepo, mockPreferenceRepo))
+            .build()
+        val result = worker.doWork()
+
+        // Assert
+        assertEquals(ListenableWorker.Result.success(), result)
+        coVerify(exactly = 1) { mockPreferenceRepo.updateLastBackupTime() }
+        coVerify(exactly = 1) { mockPasswordRepo.getAllEntries() }
+
+        // Verify that a file was actually created
+        assertTrue(backupsDir.exists())
+        assertTrue(backupsDir.listFiles()?.isNotEmpty() == true)
+        val backupFile = backupsDir.listFiles()!![0]
+        assertEquals("{\"key\":\"dummy_json\"}", backupFile.readText())
+    }
+
+    @Test
+    fun `doWork returns Success when no entries exist`() = runBlocking {
+        coEvery { mockPasswordRepo.getAllEntries() } returns emptyList()
+
+        val worker = TestListenableWorkerBuilder<BackupWorker>(context)
+            .setWorkerFactory(TestWorkerFactory(mockPasswordRepo, mockPreferenceRepo))
+            .build()
+        val result = worker.doWork()
+
+        // Assert
+        assertEquals(ListenableWorker.Result.success(), result)
+        coVerify(exactly = 0) { mockPreferenceRepo.updateLastBackupTime() }
+    }
+
+    @Test
+    fun `doWork returns Failure when repository throws an exception`() = runBlocking {
+        coEvery { mockPasswordRepo.getAllEntries() } throws RuntimeException("Database is corrupted")
+
+        val worker = TestListenableWorkerBuilder<BackupWorker>(context)
+            .setWorkerFactory(TestWorkerFactory(mockPasswordRepo, mockPreferenceRepo))
+            .build()
+        val result = worker.doWork()
+
+        // Assert
+        assertEquals(ListenableWorker.Result.failure(), result)
+    }
+}

--- a/app/src/test/java/com/jksalcedo/passvault/workers/TestWorkerFactory.kt
+++ b/app/src/test/java/com/jksalcedo/passvault/workers/TestWorkerFactory.kt
@@ -1,0 +1,33 @@
+package com.jksalcedo.passvault.workers
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import com.jksalcedo.passvault.repositories.PasswordRepository
+import com.jksalcedo.passvault.repositories.PreferenceRepository
+
+class TestWorkerFactory(
+    private val passwordRepository: PasswordRepository,
+    private val preferenceRepository: PreferenceRepository
+) : WorkerFactory() {
+
+    override fun createWorker(
+        appContext: Context,
+        workerClassName: String,
+        workerParameters: WorkerParameters
+    ): ListenableWorker? {
+        return when (workerClassName) {
+            BackupWorker::class.java.name -> {
+                BackupWorker(
+                    appContext,
+                    workerParameters,
+                    passwordRepository,
+                    preferenceRepository
+                )
+            }
+
+            else -> null
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a `BackupWorker` to handle automatic backups of password entries.

The worker performs the following steps:
- Fetches all password entries from the `PasswordRepository`.
- Skips the backup process if there are no entries.
- Retrieves the user's preferred export format (JSON or CSV) from `PreferenceRepository`.
- Serializes the data into the specified format.
- Saves the serialized data to a timestamped file in the `backups` directory.
- Updates the last backup time in `PreferenceRepository`.

Unit tests for the `BackupWorker` are also included to verify success and failure scenarios, such as when data is present, when no data exists, and when exceptions occur. A `TestWorkerFactory` is added to facilitate dependency injection in tests.