### PR TITLE
Fix: Prevent NullPointerException in BackupAdapter and disable androi…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name=".Application"
@@ -45,6 +46,12 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
+
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="remove" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/jksalcedo/passvault/adapter/BackupAdapter.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/adapter/BackupAdapter.kt
@@ -24,7 +24,7 @@ class BackupAdapter : RecyclerView.Adapter<BackupAdapter.VH>() {
 
     @SuppressLint("NotifyDataSetChanged")
     fun setBackups(list: List<File>?) {
-        _backupItems.value = list
+        _backupItems.value = list ?: emptyList()
         notifyDataSetChanged()
     }
 


### PR DESCRIPTION
…dx-startup

This commit addresses a potential NullPointerException in the `BackupAdapter` by ensuring that a null list is handled as an empty list.

It also explicitly disables the `InitializationProvider` for `androidx.startup` in the `AndroidManifest.xml` to prevent potential library initialization conflicts.