### PR TITLE
refactor: Allow device credential authentication for encryption key

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/crypto/Encryption.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/crypto/Encryption.kt
@@ -58,7 +58,7 @@ object Encryption {
                 setUserAuthenticationRequired(true)
                 setUserAuthenticationParameters(
                     0,
-                    KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_BIOMETRIC_WEAK
+                    KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
                 )
                 setIsStrongBoxBacked(true)
             }


### PR DESCRIPTION
Updates the biometric authentication settings for the encryption key to include device credentials (PIN, pattern, or password) as a valid authentication method.

The `setUserAuthenticationParameters` call is modified to use `KeyProperties.AUTH_DEVICE_CREDENTIAL` in addition to `KeyProperties.AUTH_BIOMETRIC_STRONG`, replacing the previous `KeyProperties.AUTH_BIOMETRIC_WEAK`. This provides a fallback for users who do not have biometrics set up or when a biometric sensor is unavailable.