### PR TITLE
refactor: Simplify and improve import process

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsActivity.kt
@@ -7,6 +7,7 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
@@ -16,6 +17,8 @@ import com.jksalcedo.passvault.repositories.PreferenceRepository
 import com.jksalcedo.passvault.utils.Utility
 import com.jksalcedo.passvault.viewmodel.SettingsModelFactory
 import com.jksalcedo.passvault.viewmodel.SettingsViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -39,7 +42,10 @@ class SettingsActivity : AppCompatActivity() {
                         uri,
                         password = password
                     )
-                    password = null
+                    lifecycleScope.launch {
+                        delay(1000)
+                        password = null
+                    }
                 }
             }
         }
@@ -140,6 +146,10 @@ class SettingsActivity : AppCompatActivity() {
                             password = newPassword
                             dialog.dismiss()
                             onPasswordReady(newPassword)
+                            lifecycleScope.launch {
+                                delay(1000)
+                                password = null
+                            }
                         }
 
                         newPassword != confirmPassword.toString() -> {
@@ -154,14 +164,15 @@ class SettingsActivity : AppCompatActivity() {
                             )
                             dialog.dismiss()
                             onPasswordReady(newPassword) // Proceed
+                            lifecycleScope.launch {
+                                delay(1000)
+                                password = null
+                            }
                         }
                     }
                 }
             }
             dialog.show()
-        } else {
-            // Password already exists, proceed
-            password?.let { onPasswordReady(it) }
         }
     }
 

--- a/app/src/main/java/com/jksalcedo/passvault/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/viewmodel/SettingsViewModel.kt
@@ -62,11 +62,15 @@ open class SettingsViewModel(
     private val _importResult = MutableLiveData<Result<Int>>()
     val importResult: LiveData<Result<Int>> = _importResult
 
-    private val _importUiState = MutableLiveData<ImportUiState>()
+    private val _importUiState = MutableLiveData<ImportUiState>(ImportUiState.Idle)
     val importUiState: LiveData<ImportUiState> = _importUiState
 
     companion object {
         private const val AUTO_BACKUP_WORK_TAG = "auto_backup_work"
+    }
+
+    fun resetImportState() {
+        _importUiState.value = ImportUiState.Idle
     }
 
     fun setAutoBackups(enabled: Boolean) {
@@ -200,6 +204,10 @@ open class SettingsViewModel(
                     }
                 } else {
                     fileContent
+                }
+
+                if (jsonToParse.isBlank()) {
+                    throw Exception("No entries found or invalid file format.")
                 }
 
                 //Deserialize


### PR DESCRIPTION
This commit refactors the import process to simplify the UI and improve robustness. Password handling has been unified, and the UI state is now managed more effectively.

**Key Changes:**

- **Simplified Import Dialog:** The password input field in the `ImportDialog` has been removed. All import types that require a password now consistently use the `ensurePasswordExists` flow, providing a unified user experience.

- **Improved UI State Management:**
    - The import UI state is now reset to `Idle` after an import operation succeeds or fails. This prevents the UI from getting stuck in a loading or error state.
    - Added `resetImportState()` in `SettingsViewModel` to handle this state reset.

- **Enhanced Password Handling:**
    - A `delay` is introduced in `SettingsActivity` before nullifying the password variable after use. This helps prevent race conditions where the password might be cleared before an asynchronous operation completes.

- **Better Validation:**
    - Added a check in `SettingsViewModel` to throw an exception if the file being imported is empty or has an invalid format, preventing crashes with blank JSON files.