### PR TITLE
feat: Enable manual release workflow and mark all releases as pre-rel…

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,6 +1,7 @@
 name: Android Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'
@@ -15,22 +16,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-      
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-      
+
       - name: Decode Keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: |
           echo "$KEYSTORE_BASE64" | base64 -d > app/keystore.jks
-      
+
       - name: Build Release APK
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -42,18 +43,18 @@ jobs:
             -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
             -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
             -Pandroid.injected.signing.key.password=$KEY_PASSWORD
-      
+
       - name: Get APK path
         id: apk-path
         run: |
           APK_PATH=$(find app/build/outputs/apk/release -name "*.apk" -type f | head -n 1)
           echo "path=$APK_PATH" >> $GITHUB_OUTPUT
           echo "name=$(basename $APK_PATH)" >> $GITHUB_OUTPUT
-      
+
       - name: Create Release
         uses: ncipollo/release-action@v1.20.0
         with:
           artifacts: ${{ steps.apk-path.outputs.path }}
           generateReleaseNotes: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          prerelease: true


### PR DESCRIPTION
…eases

This commit introduces two main changes to the Android release workflow:

1.  Adds the `workflow_dispatch` trigger, allowing the release workflow to be run manually from the GitHub Actions UI.
2.  Updates the release action to consistently mark all builds as pre-releases by setting `prerelease: true`, which simplifies the previous logic that checked for specific tags like 'alpha', 'beta', or 'rc'.