### PR TITLE
Remove unnecessary anotations and add compatibility checks for encryption

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/ui/addedit/AddEditActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/addedit/AddEditActivity.kt
@@ -8,7 +8,6 @@ import android.text.Editable
 import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.jksalcedo.passvault.crypto.Encryption
@@ -21,7 +20,6 @@ class AddEditActivity : AppCompatActivity(), PasswordDialogListener {
     private lateinit var viewModel: PasswordViewModel
     private var currentEntry: PasswordEntry? = null
 
-    @RequiresApi(Build.VERSION_CODES.R)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityAddEditBinding.inflate(layoutInflater)
@@ -93,7 +91,6 @@ class AddEditActivity : AppCompatActivity(), PasswordDialogListener {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
     private fun saveEntry() {
         val title = binding.etTitle.text.toString()
         val username = binding.etUsername.text.toString()

--- a/app/src/main/java/com/jksalcedo/passvault/ui/auth/SetPinFragment.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/auth/SetPinFragment.kt
@@ -1,14 +1,12 @@
 package com.jksalcedo.passvault.ui.auth
 
 import android.content.Context
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import com.jksalcedo.passvault.R
@@ -44,7 +42,6 @@ class SetPinFragment : Fragment() {
         return binding.root
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -65,7 +62,6 @@ class SetPinFragment : Fragment() {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
     private fun validateAndSavePin() {
         try {
             Encryption.ensureKeyExists()

--- a/app/src/main/java/com/jksalcedo/passvault/ui/auth/UnlockActvity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/auth/UnlockActvity.kt
@@ -1,11 +1,9 @@
 package com.jksalcedo.passvault.ui.auth
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricManager
 import com.jksalcedo.passvault.R
@@ -18,7 +16,6 @@ class UnlockActivity : AppCompatActivity(), SetPinFragment.OnPinSetListener {
     lateinit var binding: ActivityUnlockBinding
     private val biometricAuthenticator = BiometricAuthenticator()
 
-    @RequiresApi(Build.VERSION_CODES.R)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityUnlockBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/jksalcedo/passvault/ui/view/ViewEntryActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/view/ViewEntryActivity.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -57,7 +56,6 @@ class ViewEntryActivity : AppCompatActivity() {
     private val fadeIn: Animation by lazy { AnimationUtils.loadAnimation(this, R.anim.fade_in) }
     private val fadeOut: Animation by lazy { AnimationUtils.loadAnimation(this, R.anim.fade_out) }
 
-    @RequiresApi(Build.VERSION_CODES.R)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityViewEntryBinding.inflate(layoutInflater)


### PR DESCRIPTION
refactor: Remove unnecessary `@RequiresApi` annotations and add compa)tibility checks

Removes `@RequiresApi(Build.VERSION_CODES.R)` annotations from `AddEditActivity`, `ViewEntryActivity`, `SetPinFragment`, and `UnlockActivity`, as the functionality within these classes does not strictly require Android R.

In `Encryption.kt`, this refactoring introduces conditional SDK checks:
- `setUserAuthenticationParameters` is now only called on Android R (API 30) and above.
- `setIsStrongBoxBacked` is now only called on Android P (API 28) and above.

This ensures the app maintains broader compatibility with older Android versions while still leveraging modern security features on newer devices.