### PR TITLE
Refactor import/export to use plain text passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
+## [0.8.0-beta02] - 2025-11-27
+
+### Features
+
+- Refactor import/export
+
+### Documentation
+
+- Add KDoc comments to classes and public methods
+
 ## [0.8.0-beta01] - 2025-11-25
 
 ### Features
 
+- Update README with additional sections
 - Enhance backup encryption with Argon2 and refactor restart logic
 
 ## [0.7.1] - 2025-11-21

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.jksalcedo.passvault"
         minSdk = 26
         targetSdk = 36
-        versionCode = 13
-        versionName = "0.8.0-beta01"
+        versionCode = 14
+        versionName = "0.8.0-beta02"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/jksalcedo/passvault/data/ImportRecord.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/ImportRecord.kt
@@ -1,5 +1,8 @@
 package com.jksalcedo.passvault.data
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ImportRecord(
     val title: String,
     val username: String?,

--- a/app/src/main/java/com/jksalcedo/passvault/ui/settings/ImportDialog.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/settings/ImportDialog.kt
@@ -112,7 +112,10 @@ class ImportDialog : BottomSheetDialogFragment() {
     private fun openFileForImport() {
         val mimeType = when (type) {
             ImportType.BITWARDEN_JSON, ImportType.PASSVAULT_JSON -> "application/json"
-            ImportType.KEEPASS_CSV -> "text/csv"
+            ImportType.KEEPASS_CSV -> {
+                "text/csv"
+            }
+
             ImportType.KEEPASS_KDBX -> "application/octet-stream"
         }
 

--- a/app/src/test/java/com/jksalcedo/passvault/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/jksalcedo/passvault/viewmodel/SettingsViewModelTest.kt
@@ -14,9 +14,6 @@ import com.jksalcedo.passvault.data.PasswordEntry
 import com.jksalcedo.passvault.repositories.PreferenceRepository
 import com.jksalcedo.passvault.ui.settings.ImportUiState
 import com.jksalcedo.passvault.utils.Utility
-import java.io.File
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -28,6 +25,9 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
@@ -53,11 +53,15 @@ class SettingsViewModelTest {
         ).allowMainThreadQueries().build()
         AppDatabase.initializeForTesting(database)
         preferenceRepository = PreferenceRepository(application).apply { clear() }
-        viewModel = SettingsViewModel(application, activity)
+        viewModel = SettingsViewModel(application)
+        io.mockk.mockkObject(com.jksalcedo.passvault.crypto.Encryption)
+        io.mockk.every { com.jksalcedo.passvault.crypto.Encryption.encrypt(any()) } returns Pair("cipher", "iv")
+        io.mockk.every { com.jksalcedo.passvault.crypto.Encryption.decrypt(any(), any()) } returns "password"
     }
 
     @After
     fun tearDown() {
+        io.mockk.unmockkAll()
         database.clearAllTables()
     }
 

--- a/metadata/en-US/changelogs/14.txt
+++ b/metadata/en-US/changelogs/14.txt
@@ -1,0 +1,7 @@
+Features
+
+- Refactor import/export
+
+Documentation
+
+- Add KDoc comments to classes and public methods


### PR DESCRIPTION
This commit introduces a significant change to the import/export functionality. Instead of serializing the encrypted password and IV, the process now decrypts passwords before exporting and re-encrypts them upon import.

This change enhances data portability and simplifies the structure of the exported JSON/CSV files. A new `ImportRecord` data class has been created to handle this plain text intermediate format. Fallback logic is included to ensure backward compatibility with the old import format.

Key changes:
- Introduced `ImportRecord.kt` for plain text serialization.
- Updated `Utility.kt` to handle decryption on export and encryption on import.
- Added backward compatibility for importing old data formats.
- Refactored and expanded tests for `Utility.kt` and `SettingsViewModelTest.kt` to cover the new logic and mock encryption.