### PR TITLE
Allow importing entries with empty passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [unreleased]
+## [0.8.0] - 2025-11-30
+
+### Bug Fixes
+
+- Allow importing entries with empty passwords
+
+## [0.8.0-beta02] - 2025-11-27
 
 ### Features
 
@@ -11,6 +17,7 @@
 ### Miscellaneous Tasks
 
 - Simplify APK artifact path in release workflow
+
 ## [0.8.0-beta01] - 2025-11-25
 
 ### Features
@@ -19,6 +26,7 @@
 - Enhance backup encryption with Argon2 and refactor restart logic
 - Enhance backup encryption with Argon2 and refactor restart logic
 - Enhance backup encryption and refactor restart logic
+
 ## [0.7.1] - 2025-11-21
 
 ### Other
@@ -34,6 +42,7 @@
 - Allow format override during import
 - Enhance serialization, timestamp format, and importer logic
 - Enhance import logic and replace launcher icons
+
 ## [0.7.0] - 2025-11-20
 
 ### Features
@@ -49,6 +58,7 @@
 ### Miscellaneous Tasks
 
 - Update CHANGELOG for version 0.7.0
+
 ## [0.7.0-beta01] - 2025-11-20
 
 ### Features
@@ -69,6 +79,7 @@
 
 - Update IDE configurations and build script
 - Update dependencies and clean up IDE configurations
+
 ## [0.6.0] - 2025-11-18
 
 ### Refactor
@@ -85,6 +96,7 @@
 ### Miscellaneous Tasks
 
 - Bump version to 0.6.0
+
 ## [0.6.0-beta2] - 2025-11-18
 
 ### Other
@@ -96,6 +108,7 @@
 - Replace SetPinDialog with SetPinFragment for a full-screen UI
 - Improve Password Generator dialog and SharedPreferences usage
 - Improve password dialogs and replace AlertDialog
+
 ## [0.6.0-beta] - 2025-11-17
 
 ### Features
@@ -138,6 +151,7 @@
 ### Refactor
 
 - Remove unused TestWorkerFactory
+
 ## [0.5.0] - 2025-11-15
 
 ### Features
@@ -149,6 +163,7 @@
 
 - Add Toolbar and Up Navigation to Add/Edit screen
 - Simplify ViewEntryActivity and layout
+
 ## [0.4-beta] - 2025-11-08
 
 ### Features
@@ -159,11 +174,13 @@
 
 - Add database size utility functions
 - Rename APK artifact and update version
+
 ## [0.4-alpha] - 2025-11-07
 
 ### Other
 
 - Rename "Passkey" to "Password" for clarity
+
 ## [0.3-alpha] - 2025-11-06
 
 ### Features
@@ -177,6 +194,7 @@
 - Add delete functionality and confirmation dialog
 - Correct FAB layout and add content descriptions
 - Correct FAB layout and add content descriptions
+
 ## [0.2-alpha] - 2025-11-04
 
 ### Other
@@ -185,4 +203,5 @@
 - Rename `AddActivity` to `AddEditActivity` and move files
 - Implement comprehensive testing and improve Add/Edit functionality
 - Update variable and preference key names for clarity
+
 ## [0.1-alpha] - 2025-11-02

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.jksalcedo.passvault"
         minSdk = 26
         targetSdk = 36
-        versionCode = 14
-        versionName = "0.8.0-beta02"
+        versionCode = 15
+        versionName = "0.8.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/jksalcedo/passvault/importer/BitwardenImporter.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/importer/BitwardenImporter.kt
@@ -20,7 +20,7 @@ class BitwardenImporter(
         try {
             val export = json.decodeFromString<BitwardenExport>(raw)
             return export.items
-                .filter { it.type == 1 && it.login?.password?.isNotBlank() == true }
+                .filter { it.type == 1 && (it.name.isNotBlank() || it.login?.password?.isNotBlank() == true) }
                 .map { item ->
                     ImportRecord(
                         title = item.name,

--- a/app/src/main/java/com/jksalcedo/passvault/importer/KeePassImporter.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/importer/KeePassImporter.kt
@@ -64,7 +64,7 @@ class KeePassImporter(
             val parsedRows = csv.decodeFromString<List<KeepassRecord>>(raw)
             parsedRows.mapNotNull { row ->
                 val password = row.password.trim()
-                if (password.isEmpty()) return@mapNotNull null
+                if (password.isEmpty() && row.title.isBlank()) return@mapNotNull null
 
                 val keepassRecord = KeepassRecord(
                     title = row.title.trim(),
@@ -114,14 +114,14 @@ class KeePassImporter(
                 val password = entry.fields.password?.content
                 val notes = entry.fields.notes?.content
 
-                if (title.isNullOrBlank() || password.isNullOrEmpty()) {
+                if (title.isNullOrBlank() && password.isNullOrEmpty()) {
                     return@mapNotNull null
                 }
 
                 ImportRecord(
-                    title = title,
+                    title = title!!,
                     username = username,
-                    password = password,
+                    password = password!!,
                     notes = notes,
                     createdAt = entry.times?.creationTime?.toEpochMilli(),
                     updatedAt = entry.times?.lastModificationTime?.toEpochMilli()

--- a/app/src/test/java/com/jksalcedo/passvault/importer/KeepassDxCsvImporterTest.kt
+++ b/app/src/test/java/com/jksalcedo/passvault/importer/KeepassDxCsvImporterTest.kt
@@ -63,10 +63,12 @@ GitLab,bob,validpass,MoreNotes,2007-12-03T10:15:30Z,2007-12-03T10:15:30Z
         val importer = KeePassImporter()
         val records = importer.parse(csv)
 
-        // Only the row with valid password should be included
-        assertEquals(1, records.size)
-        assertEquals("GitLab", records[0].title)
-        assertEquals("validpass", records[0].password)
+        // Both rows should be included now
+        assertEquals(2, records.size)
+        assertEquals("GitHub", records[0].title)
+        assertEquals("", records[0].password)
+        assertEquals("GitLab", records[1].title)
+        assertEquals("validpass", records[1].password)
     }
 
     @Test
@@ -80,9 +82,11 @@ GitLab,bob,validpass,MoreNotes,2007-12-03T10:15:30Z,2007-12-03T10:15:30Z
         val importer = KeePassImporter()
         val records = importer.parse(csv)
 
-        // Only the row with non-empty password should be included
-        assertEquals(1, records.size)
-        assertEquals("GitLab", records[0].title)
+        // Both rows should be included now
+        assertEquals(2, records.size)
+        assertEquals("GitHub", records[0].title)
+        assertEquals("", records[0].password)
+        assertEquals("GitLab", records[1].title)
     }
 
     @Test
@@ -97,8 +101,8 @@ GitLab,bob,validpass,MoreNotes,2007-12-03T10:15:30Z,2007-12-03T10:15:30Z
         val records = importer.parse(csv)
 
         // Only the row with non-whitespace password should be included
-        assertEquals(1, records.size)
-        assertEquals("GitLab", records[0].title)
+        assertEquals(2, records.size)
+        assertEquals("GitLab", records[1].title)
     }
 
     @Test
@@ -146,7 +150,7 @@ newlines,2007-12-03T10:15:30Z,2007-12-03T10:15:30Z
         val importer = KeePassImporter()
         val records = importer.parse(csv)
 
-        assertEquals(1, records.size)
+        assertEquals(2, records.size)
         assertEquals("Title, with comma", records[0].title)
         assertEquals("user@email.com", records[0].username)
         assertTrue(records[0].password.isNotEmpty())

--- a/metadata/en-US/changelogs/15.txt
+++ b/metadata/en-US/changelogs/15.txt
@@ -1,0 +1,14 @@
+Features
+
+- Update README with additional sections
+- Enhance backup encryption with Argon2 and refactor restart logic
+- Enhance backup encryption and refactor restart logic
+- Refactor import/export to use plain text passwords
+
+Bug Fixes
+
+- Allow importing entries with empty passwords
+
+Miscellaneous Tasks
+
+- Simplify APK artifact path in release workflow


### PR DESCRIPTION
This commit adjusts the import logic for Bitwarden and KeePass to allow the import of entries that have a title but an empty password.

Previously, entries with empty passwords were skipped. Now, an entry is imported if it has either a non-blank title or a non-blank password, making the import process more permissive.

The tests for the KeePass importer have been updated to reflect this change, and the app version has been bumped to `0.8.0`.