### PR TITLE
feat: Add search functionality

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -2,6 +2,7 @@
   <dictionary name="project">
     <words>
       <w>bitwarden</w>
+      <w>jksalcedo</w>
     </words>
   </dictionary>
 </component>

--- a/app/src/main/java/com/jksalcedo/passvault/data/PasswordDao.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/PasswordDao.kt
@@ -27,4 +27,7 @@ interface PasswordDao {
 
     @Delete
     suspend fun delete(entry: PasswordEntry)
+
+    @Query("SELECT * FROM password_entries WHERE title LIKE :query OR username LIKE :query")
+    suspend fun search(query: String): List<PasswordEntry>
 }

--- a/app/src/main/java/com/jksalcedo/passvault/repositories/PasswordRepository.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/repositories/PasswordRepository.kt
@@ -62,4 +62,7 @@ class PasswordRepository(context: Context) {
         passwordDao.delete(entry)
     }
 
+    suspend fun search(query: String): List<PasswordEntry> {
+        return passwordDao.search("%$query%")
+    }
 }

--- a/app/src/main/java/com/jksalcedo/passvault/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/main/MainActivity.kt
@@ -1,13 +1,17 @@
 package com.jksalcedo.passvault.ui.main
 
+import android.annotation.SuppressLint
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.widget.SearchView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.jksalcedo.passvault.R
 import com.jksalcedo.passvault.adapter.PVAdapter
@@ -16,6 +20,9 @@ import com.jksalcedo.passvault.ui.addedit.AddEditActivity
 import com.jksalcedo.passvault.ui.settings.SettingsActivity
 import com.jksalcedo.passvault.ui.view.ViewEntryActivity
 import com.jksalcedo.passvault.viewmodel.PasswordViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * The main activity of the app.
@@ -61,8 +68,38 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun performSearch(query: String?) {
+        lifecycleScope.launch {
+            if (!query.isNullOrEmpty()) {
+                val result = withContext(Dispatchers.IO) {
+                    viewModel.search(query)
+                }
+                adapter.submitList(result)
+            } else {
+                adapter.submitList(viewModel.allEntries.value)
+            }
+        }
+    }
+
+    @SuppressLint("DiscouragedApi")
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu_main, menu)
+        val searchView = menu.findItem(R.id.action_search).actionView as SearchView
+        val searchPlateId =
+            searchView.context.resources.getIdentifier("android:id/search_plate", null, null)
+        val searchPlate = searchView.findViewById<View>(searchPlateId)
+        searchPlate?.setBackgroundColor(Color.TRANSPARENT)
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextChange(newText: String?): Boolean {
+                performSearch(newText)
+                return true
+            }
+
+            override fun onQueryTextSubmit(query: String?): Boolean {
+                return true
+            }
+
+        })
         return true
     }
 

--- a/app/src/main/java/com/jksalcedo/passvault/viewmodel/PasswordViewModel.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/viewmodel/PasswordViewModel.kt
@@ -28,4 +28,8 @@ class PasswordViewModel(app: Application) : AndroidViewModel(app) {
     fun delete(entry: PasswordEntry) {
         viewModelScope.launch(Dispatchers.IO) { passwordRepository.delete(entry) }
     }
+
+    suspend fun search(query: String): List<PasswordEntry> {
+        return passwordRepository.search(query)
+    }
 }

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="22dp"
+    android:height="22dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M23.707,22.293l-5.969,-5.969a10.016,10.016 0,1 0,-1.414 1.414l5.969,5.969a1,1 0,0 0,1.414 -1.414ZM10,18a8,8 0,1 1,8 -8A8.009,8.009 0,0 1,10 18Z"/>
+</vector>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -7,4 +7,13 @@
         android:orderInCategory="100"
         android:title="@string/action_settings"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_search"
+        android:icon="@drawable/ic_search"
+        android:orderInCategory="1"
+        android:title="@string/search"
+
+        app:actionViewClass="android.widget.SearchView"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="keepass_csv">KeePass (CSV)</string>
     <string name="keepass_kdbx">KeePass (KDBX)</string>
     <string name="passvault_json">PassVault (JSON)</string>
+    <string name="search">Search</string>
 
     <string-array name="backup_options">
         <item>Restore</item>


### PR DESCRIPTION
This commit introduces search functionality to the main screen, allowing users to filter their password entries.

A search icon and a corresponding search view have been added to the main toolbar. The search is performed on both the title and username fields of the password entries as the user types.

Key changes include:
- A new `search` method in the `PasswordDao`, `PasswordRepository`, and `PasswordViewModel`.
- Integration of a `SearchView` into `MainActivity` to handle user queries.
- Addition of a search icon drawable and string resource.