### PR TITLE
feat: Add URL field to password entries

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/data/Bitwarden.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/Bitwarden.kt
@@ -16,7 +16,13 @@ data class BitwardenItem(
 @Serializable
 data class BitwardenLogin(
     val username: String? = null,
-    val password: String? = null
+    val password: String? = null,
+    val uris: List<BitwardenUris?>
+)
+
+@Serializable
+data class BitwardenUris(
+    val uri: String
 )
 
 @Serializable

--- a/app/src/main/java/com/jksalcedo/passvault/data/ImportRecord.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/ImportRecord.kt
@@ -7,6 +7,9 @@ data class ImportRecord(
     val title: String,
     val username: String?,
     val password: String,
+    val email: String? = null,
+    val url: String? = null,
+    val category: String? = null,
     val notes: String?,
     val createdAt: Long?,
     val updatedAt: Long?

--- a/app/src/main/java/com/jksalcedo/passvault/data/KeepassRecord.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/KeepassRecord.kt
@@ -11,6 +11,8 @@ data class KeepassRecord(
     val username: String = "",
     @SerialName("Password")
     val password: String = "",
+    @SerialName("URL")
+    val url: String = "",
     @SerialName("Notes")
     val notes: String = "",
     @SerialName("CreationTime")

--- a/app/src/main/java/com/jksalcedo/passvault/importer/BitwardenImporter.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/importer/BitwardenImporter.kt
@@ -26,6 +26,9 @@ class BitwardenImporter(
                         title = item.name,
                         username = item.login?.username,
                         password = item.login?.password.orEmpty(),
+                        email = null,
+                        url = item.login?.uris?.first()?.uri,
+                        category = null,
                         notes = item.notes,
                         createdAt = item.creationDate?.toEpochMillis(),
                         updatedAt = item.revisionDate?.toEpochMillis()

--- a/app/src/main/java/com/jksalcedo/passvault/importer/KeePassImporter.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/importer/KeePassImporter.kt
@@ -70,6 +70,7 @@ class KeePassImporter(
                     title = row.title.trim(),
                     username = row.username.trim(),
                     password = password,
+                    url = row.url,
                     notes = row.notes.trim(),
                     creationTime = row.creationTime,
                     lastModificationTime = row.lastModificationTime
@@ -79,6 +80,7 @@ class KeePassImporter(
                     title = keepassRecord.title,
                     username = keepassRecord.username,
                     password = keepassRecord.password,
+                    url = keepassRecord.url,
                     notes = keepassRecord.notes,
                     createdAt = keepassRecord.creationTime.toEpochMillis(),
                     updatedAt = keepassRecord.lastModificationTime.toEpochMillis()
@@ -112,6 +114,7 @@ class KeePassImporter(
                 val title = entry.fields.title?.content
                 val username = entry.fields.userName?.content
                 val password = entry.fields.password?.content
+                val url = entry.fields.url?.content
                 val notes = entry.fields.notes?.content
 
                 // Skip entries that have both empty title AND empty password
@@ -123,6 +126,7 @@ class KeePassImporter(
                     title = title.orEmpty(),
                     username = username,
                     password = password.orEmpty(),
+                    url = url,
                     notes = notes,
                     createdAt = entry.times?.creationTime?.toEpochMilli(),
                     updatedAt = entry.times?.lastModificationTime?.toEpochMilli()

--- a/app/src/main/java/com/jksalcedo/passvault/utils/Utility.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/utils/Utility.kt
@@ -104,6 +104,9 @@ object Utility {
             username = username,
             passwordCipher = cipher,
             passwordIv = iv,
+            email = email,
+            url = url,
+            category = category,
             notes = notes,
             createdAt = createdAt ?: System.currentTimeMillis(),
             updatedAt = updatedAt ?: System.currentTimeMillis()
@@ -120,6 +123,9 @@ object Utility {
             title = this.title,
             username = this.username,
             password = password,
+            email = this.email,
+            url = this.url,
+            category = this.category,
             notes = this.notes,
             createdAt = this.createdAt,
             updatedAt = this.updatedAt


### PR DESCRIPTION
This commit introduces a `url` field to password entries, allowing for the storage and import of website addresses associated with credentials.

The changes include:
- Adding a `url` property to the `ImportRecord` and `KeepassRecord` data classes.
- Updating the `Bitwarden` data model to parse URIs from the import file.
- Modifying the `BitwardenImporter` and `KeePassImporter` to extract and map the URL during the import process.
- Extending the `toPassword` and `toImportRecord` utility functions to handle the new `url` field.