### PR TITLE
Refactor backup file saving to use ACTION_CREATE_DOCUMENT

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/ui/settings/BackupsFragment.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/settings/BackupsFragment.kt
@@ -86,7 +86,11 @@ class BackupsFragment : Fragment() {
                         }
                         // Save & Copy
                         1 -> {
-                            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+                            val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                                addCategory(Intent.CATEGORY_OPENABLE)
+                                type = "application/octet-stream"
+                                putExtra(Intent.EXTRA_TITLE, item.name)
+                            }
                             openFileLauncher.launch(intent)
                         }
                         // Delete


### PR DESCRIPTION
This commit changes the intent used for saving backup files from `ACTION_OPEN_DOCUMENT_TREE` to `ACTION_CREATE_DOCUMENT`.

This refinement provides a more direct and user-friendly file-saving experience. Instead of asking the user to select a directory, it now opens a file creation dialog with the backup name pre-filled, allowing the user to simply choose a location and save.

Key changes:
- The intent for the "Save & Copy" backup option is now `ACTION_CREATE_DOCUMENT`.
- The intent type is set to `application/octet-stream` and is categorized as `CATEGORY_OPENABLE`.
- The backup's filename is passed as `Intent.EXTRA_TITLE` to pre-fill the name in the save dialog.