### PR TITLE
refactor: Relocate enums to a dedicated package

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/data/enums/Action.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/enums/Action.kt
@@ -1,0 +1,5 @@
+package com.jksalcedo.passvault.data.enums
+
+enum class Action {
+    IMPORT, EXPORT
+}

--- a/app/src/main/java/com/jksalcedo/passvault/data/enums/ImportType.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/enums/ImportType.kt
@@ -1,0 +1,9 @@
+package com.jksalcedo.passvault.data.enums
+
+enum class ImportType {
+    PASSVAULT_JSON,
+    PASSVAULT_CSV,
+    BITWARDEN_JSON,
+    KEEPASS_CSV,
+    KEEPASS_KDBX
+}

--- a/app/src/main/java/com/jksalcedo/passvault/data/enums/SortOption.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/enums/SortOption.kt
@@ -1,8 +1,5 @@
-package com.jksalcedo.passvault.data
+package com.jksalcedo.passvault.data.enums
 
-/**
- * Enum representing different sorting options for password entries.
- */
 enum class SortOption {
     NAME_ASC,
     NAME_DESC,
@@ -13,9 +10,6 @@ enum class SortOption {
     CATEGORY_ASC;
 
     companion object {
-        /**
-         * Gets a SortOption from its string name, with a fallback default.
-         */
         fun fromString(value: String?): SortOption {
             return try {
                 valueOf(value ?: "NAME_ASC")

--- a/app/src/main/java/com/jksalcedo/passvault/importer/KeePassImporter.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/importer/KeePassImporter.kt
@@ -7,7 +7,7 @@ import app.keemobile.kotpass.database.KeePassDatabase
 import app.keemobile.kotpass.database.decode
 import com.jksalcedo.passvault.data.ImportRecord
 import com.jksalcedo.passvault.data.KeepassRecord
-import com.jksalcedo.passvault.ui.settings.ImportType
+import com.jksalcedo.passvault.data.enums.ImportType
 import com.jksalcedo.passvault.utils.Utility.toEpochMillis
 import com.jksalcedo.passvault.utils.Utility.toPasswordEntry
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/app/src/main/java/com/jksalcedo/passvault/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/main/MainActivity.kt
@@ -14,7 +14,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.chip.Chip
 import com.jksalcedo.passvault.R
 import com.jksalcedo.passvault.adapter.PVAdapter
-import com.jksalcedo.passvault.data.SortOption
+import com.jksalcedo.passvault.data.enums.SortOption
 import com.jksalcedo.passvault.databinding.ActivityMainBinding
 import com.jksalcedo.passvault.ui.addedit.AddEditActivity
 import com.jksalcedo.passvault.ui.addedit.PasswordDialogListener

--- a/app/src/main/java/com/jksalcedo/passvault/ui/settings/ImportDialog.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/settings/ImportDialog.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.viewModels
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.jksalcedo.passvault.databinding.DialogImportBinding
+import com.jksalcedo.passvault.data.enums.ImportType
 import com.jksalcedo.passvault.utils.Utility
 import com.jksalcedo.passvault.viewmodel.SettingsModelFactory
 import com.jksalcedo.passvault.viewmodel.SettingsViewModel
@@ -177,12 +178,4 @@ class ImportDialog : BottomSheetDialogFragment() {
         super.onDestroy()
         _binding = null
     }
-}
-
-enum class ImportType {
-    PASSVAULT_JSON,
-    PASSVAULT_CSV,
-    BITWARDEN_JSON,
-    KEEPASS_CSV,
-    KEEPASS_KDBX
 }

--- a/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsFragment.kt
@@ -12,6 +12,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.jksalcedo.passvault.R
+import com.jksalcedo.passvault.data.enums.Action
 import com.jksalcedo.passvault.repositories.PreferenceRepository
 import com.jksalcedo.passvault.ui.auth.BiometricAuthenticator
 import com.jksalcedo.passvault.utils.Utility
@@ -435,8 +436,4 @@ class SettingsFragment : PreferenceFragmentCompat() {
         super.onDetach()
         settingsActivity = null
     }
-}
-
-enum class Action {
-    IMPORT, EXPORT
 }

--- a/app/src/main/java/com/jksalcedo/passvault/viewmodel/PasswordViewModel.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/viewmodel/PasswordViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.map
 import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.jksalcedo.passvault.data.PasswordEntry
-import com.jksalcedo.passvault.data.SortOption
+import com.jksalcedo.passvault.data.enums.SortOption
 import com.jksalcedo.passvault.repositories.PasswordRepository
 import com.jksalcedo.passvault.repositories.PreferenceRepository
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/jksalcedo/passvault/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/viewmodel/SettingsViewModel.kt
@@ -27,7 +27,7 @@ import com.jksalcedo.passvault.data.ImportRecord
 import com.jksalcedo.passvault.importer.BitwardenImporter
 import com.jksalcedo.passvault.importer.KeePassImporter
 import com.jksalcedo.passvault.repositories.PreferenceRepository
-import com.jksalcedo.passvault.ui.settings.ImportType
+import com.jksalcedo.passvault.data.enums.ImportType
 import com.jksalcedo.passvault.ui.settings.ImportUiState
 import com.jksalcedo.passvault.utils.Utility
 import com.jksalcedo.passvault.utils.Utility.toPasswordEntry


### PR DESCRIPTION
This commit refactors the codebase by moving existing enum classes into a new `data.enums` package for better organization and code structure.

Key changes:
- Created a new package `com.jksalcedo.passvault.data.enums`.
- Moved `SortOption`, `ImportType`, and `Action` enums to the new package.
- Deleted the old `SortOption.kt` file and removed the inline `ImportType` and `Action` enums from their respective UI files.
- Updated all import statements across the application to reference the new location of these enums.