### PR TITLE
fix(UI): Correct FAB position and fix settings crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.1.0] - 2025-12-09
+## [1.2.0] - 2025-12-12
 
 ### Features
 
@@ -23,6 +23,7 @@
 - Add custom backup location and retention policy
 - Refactor backup file saving to use ACTION_CREATE_DOCUMENT
 - Add backup copies setting and refactor code
+- Add backup copies setting and refactor code
 
 ### Refactor
 
@@ -41,8 +42,12 @@
 - Add email and URL validation
 - Add button to open URL in browser
 - Add category filter functionality
+- Add category filter functionality
+- Add URL field, category filter, and other enhancements
+- Add URL field, category filter, and other enhancements
 - Add password strength analyzer
 - Improve export/import robustness and add Keystore validation
+- Add sorting functionality for password entries
 - Add sorting functionality for password entries
 
 ### Other
@@ -56,11 +61,13 @@
 ### Styling
 
 - Update Store screenshot
+- Update Store screenshot
 
 ## [1.0.0-beta01] - 2025-12-07
 
 ### Features
 
+- Add categories and enhance entry fields
 - Add categories and enhance entry fields
 
 ## [0.9.1] - 2025-12-02

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.jksalcedo.passvault"
         minSdk = 26
         targetSdk = 36
-        versionCode = 20
-        versionName = "1.2.0"
+        versionCode = 21
+        versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/jksalcedo/passvault/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/main/MainActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
+import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -59,6 +60,7 @@ class MainActivity : BaseActivity(), PasswordDialogListener {
             val params =
                 binding.fabAdd.layoutParams as androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams
             params.anchorId = binding.bottomAppBar.id
+            params.setMargins(0, 0, 0, 0)
             binding.fabAdd.layoutParams = params
 
             // Add top padding to chips to avoid status bar overlap
@@ -81,6 +83,9 @@ class MainActivity : BaseActivity(), PasswordDialogListener {
             val params =
                 binding.fabAdd.layoutParams as androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams
             params.anchorId = View.NO_ID
+            params.gravity = Gravity.BOTTOM or Gravity.END
+            val margin = (16 * resources.displayMetrics.density).toInt()
+            params.setMargins(0, 0, margin, margin)
             binding.fabAdd.layoutParams = params
         }
 

--- a/app/src/main/res/xml/settings_root.xml
+++ b/app/src/main/res/xml/settings_root.xml
@@ -1,27 +1,27 @@
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceScreen
-        app:fragment="com.jksalcedo.passvault.ui.settings.SettingsFragment"
-        app:icon="@drawable/ic_security"
-        app:key="pref_security"
-        app:title="Security" />
+        android:fragment="com.jksalcedo.passvault.ui.settings.SettingsFragment"
+        android:icon="@drawable/ic_security"
+        android:key="pref_security"
+        android:title="Security" />
 
     <PreferenceScreen
-        app:fragment="com.jksalcedo.passvault.ui.settings.SettingsFragment"
-        app:icon="@drawable/ic_display"
-        app:key="pref_display"
-        app:title="Display" />
+        android:fragment="com.jksalcedo.passvault.ui.settings.SettingsFragment"
+        android:icon="@drawable/ic_display"
+        android:key="pref_display"
+        android:title="Display" />
 
     <PreferenceScreen
-        app:fragment="com.jksalcedo.passvault.ui.settings.SettingsFragment"
-        app:icon="@drawable/ic_backup"
-        app:key="pref_data_sync"
-        app:title="Vault &amp; Data" />
+        android:fragment="com.jksalcedo.passvault.ui.settings.SettingsFragment"
+        android:icon="@drawable/ic_backup"
+        android:key="pref_data_sync"
+        android:title="Vault &amp; Data" />
 
     <PreferenceScreen
-        app:fragment="com.jksalcedo.passvault.ui.settings.SettingsFragment"
-        app:icon="@drawable/ic_info"
-        app:key="pref_about"
-        app:title="About" />
+        android:fragment="com.jksalcedo.passvault.ui.settings.SettingsFragment"
+        android:icon="@drawable/ic_info"
+        android:key="pref_about"
+        android:title="About" />
 
 </PreferenceScreen>

--- a/metadata/en-US/changelogs/21.txt
+++ b/metadata/en-US/changelogs/21.txt
@@ -1,0 +1,2 @@
+- fix fab layout gravity when not in bottom appbar
+- fix crashing on settings screen caused by incorrect namespace declaration on preference root


### PR DESCRIPTION
This commit addresses two key issues:
- A layout bug where the Floating Action Button (FAB) was incorrectly positioned when not anchored to the bottom app bar.
- A crash occurring on the settings screen due to an incorrect XML namespace declaration.

Key changes:
- In `MainActivity.kt`, the layout parameters for the FAB are now correctly set with `Gravity.BOTTOM or Gravity.END` and appropriate margins when it is not attached to the `BottomAppBar`.
- In `settings_root.xml`, the XML namespace has been corrected from `app` to `android` to prevent the application from crashing when navigating to the settings screen.
- The app version has been incremented to `1.2.1` and `versionCode` to `21`.
- A new changelog file for version `21` has been added, documenting these fixes.

Resolves #136 
Resolves #135 