### PR TITLE
refactor(UI): Improve contrast and update icons

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     id("kotlin-parcelize")
     id("com.autonomousapps.dependency-analysis")
+    id("com.google.android.gms.oss-licenses-plugin")
 }
 
 android {
@@ -18,8 +19,8 @@ android {
         applicationId = "com.jksalcedo.passvault"
         minSdk = 26
         targetSdk = 36
-        versionCode = 21
-        versionName = "1.2.1"
+        versionCode = 22
+        versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -167,4 +168,7 @@ dependencies {
 
     // Argon2
     implementation(libs.argon2kt)
+
+    implementation(libs.play.services.oss.licenses)
+
 }

--- a/app/src/main/java/com/jksalcedo/passvault/ui/addedit/PasswordGenDialog.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/addedit/PasswordGenDialog.kt
@@ -50,6 +50,7 @@ class PasswordGenDialog : DialogFragment() {
         val savedLength = prefs.getInt("length", 16)
         binding.sbLength.progress = savedLength
         binding.tvLength.text = savedLength.toString()
+        binding.sbLength.min = 4
 
         binding.sbUppercase.isChecked = prefs.getBoolean("uppercase", true)
         binding.sbLowercase.isChecked = prefs.getBoolean("lowercase", true)
@@ -68,6 +69,7 @@ class PasswordGenDialog : DialogFragment() {
 
         val dialog = MaterialAlertDialogBuilder(requireContext())
             .setView(binding.root)
+            .setTitle(R.string.generate_password)
             .setCancelable(false)
             // This button generates the password and shows it, but does nor close the dialog
             .setPositiveButton("Generate", null)
@@ -97,7 +99,6 @@ class PasswordGenDialog : DialogFragment() {
         dialog.setOnShowListener {
             val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
             positiveButton.setOnClickListener {
-                // Read the UI state right when the button is clicked
                 val length = binding.sbLength.progress
                 val hasUppercase = binding.sbUppercase.isChecked
                 val hasLowercase = binding.sbLowercase.isChecked

--- a/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsFragment.kt
@@ -10,6 +10,7 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -84,11 +85,19 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 setupAboutPreference()
                 setupGitHubLink()
                 setupTelegramLink()
+                setupOSSLicenses()
             }
 
             else -> {
                 setPreferencesFromResource(R.xml.settings_root, rootKey)
             }
+        }
+    }
+
+    private fun setupOSSLicenses() {
+        findPreference<Preference>("licenses")?.setOnPreferenceClickListener {
+            startActivity(Intent(this.requireContext(), OssLicensesMenuActivity::class.java))
+            true
         }
     }
 
@@ -518,7 +527,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val uriString = prefsRepository.getBackupLocation()
         val summary = if (uriString != null) {
             try {
-                val uri = android.net.Uri.parse(uriString)
+                val uri = uriString.toUri()
                 val documentFile =
                     androidx.documentfile.provider.DocumentFile.fromTreeUri(requireContext(), uri)
                 documentFile?.name ?: uriString

--- a/app/src/main/res/drawable/ic_backup.xml
+++ b/app/src/main/res/drawable/ic_backup.xml
@@ -7,77 +7,77 @@
         android:fillColor="#00000000"
         android:pathData="M4,6c0,1.657 3.582,3 8,3s8,-1.343 8,-3s-3.582,-3 -8,-3s-8,1.343 -8,3"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M4,6v6c0,1.657 3.582,3 8,3c0.21,0 0.42,-0.003 0.626,-0.01"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M20,11.5v-5.5"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M4,12v6c0,1.657 3.582,3 8,3"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19.001,19m-2,0a2,2 0,1 0,4 0a2,2 0,1 0,-4 0"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19.001,15.5v1.5"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19.001,21v1.5"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M22.032,17.25l-1.299,0.75"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M17.27,20l-1.3,0.75"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M15.97,17.25l1.3,0.75"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M20.733,20l1.3,0.75"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
 </vector>

--- a/app/src/main/res/drawable/ic_display.xml
+++ b/app/src/main/res/drawable/ic_display.xml
@@ -7,21 +7,21 @@
         android:fillColor="#00000000"
         android:pathData="M19.03,17.818a3,3 0,0 0,1.97 -2.818v-8a3,3 0,0 0,-3 -3h-12a3,3 0,0 0,-3 3v8c0,1.317 0.85,2.436 2.03,2.84"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M10,14a2,2 0,1 0,4 0a2,2 0,0 0,-4 0"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M8,21a2,2 0,0 1,2 -2h4a2,2 0,0 1,2 2"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
 </vector>

--- a/app/src/main/res/drawable/ic_info.xml
+++ b/app/src/main/res/drawable/ic_info.xml
@@ -7,21 +7,21 @@
         android:fillColor="#00000000"
         android:pathData="M3,12a9,9 0,1 0,18 0a9,9 0,0 0,-18 0"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M12,9h0.01"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M11,12h1v4h1"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
 </vector>

--- a/app/src/main/res/drawable/ic_security.xml
+++ b/app/src/main/res/drawable/ic_security.xml
@@ -7,14 +7,14 @@
         android:fillColor="#00000000"
         android:pathData="M16.555,3.843l3.602,3.602a2.877,2.877 0,0 1,0 4.069l-2.643,2.643a2.877,2.877 0,0 1,-4.069 0l-0.301,-0.301l-6.558,6.558a2,2 0,0 1,-1.239 0.578l-0.175,0.008h-1.172a1,1 0,0 1,-0.993 -0.883l-0.007,-0.117v-1.172a2,2 0,0 1,0.467 -1.284l0.119,-0.13l0.414,-0.414h2v-2h2v-2l2.144,-2.144l-0.301,-0.301a2.877,2.877 0,0 1,0 -4.069l2.643,-2.643a2.877,2.877 0,0 1,4.069 0z"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M15,9h0.01"
         android:strokeWidth="1.75"
-        android:strokeColor="?attr/colorControlNormal"
+        android:strokeColor="@android:color/darker_gray"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
 </vector>

--- a/app/src/main/res/layout/dialog_password_gen.xml
+++ b/app/src/main/res/layout/dialog_password_gen.xml
@@ -3,19 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="24dp">
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/materialTextView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="start"
-        android:text="@string/generate_password"
-        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="24dp">
 
     <LinearLayout
         android:id="@+id/linearLayout"
@@ -24,20 +13,23 @@
         android:layout_marginTop="24dp"
         android:gravity="center"
         android:orientation="horizontal"
-        app:layout_constraintTop_toBottomOf="@+id/materialTextView"
+        app:layout_constraintTop_toTopOf="parent"
         tools:layout_editor_absoluteX="12dp">
 
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/length" />
+            android:text="@string/length"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/tvLength"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
-            android:text="[16]" />
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+            android:textStyle="bold"
+            tools:text="[16]" />
 
         <androidx.appcompat.widget.AppCompatSeekBar
             android:id="@+id/sbLength"
@@ -46,7 +38,7 @@
             android:layout_weight="1"
             android:progress="16"
             android:scaleX="1"
-            android:scrollbarSize="12dp" />
+            android:scrollbarSize="20dp" />
     </LinearLayout>
 
 
@@ -121,7 +113,8 @@
         android:gravity="start|center_vertical"
         android:minHeight="54dp"
         android:paddingHorizontal="16dp"
-        android:paddingVertical="4dp"
+        android:paddingVertical="8dp"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/cbSymbols" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -23,7 +23,7 @@
         <item name="colorSurfaceContainerLow">@color/white</item>
         <item name="colorSurfaceContainerHigh">@color/grey_100</item>
         <item name="colorOnSurface">@color/black</item>
-        <item name="colorOnSurfaceVariant">@color/grey_500</item>
+        <item name="colorOnSurfaceVariant">@color/grey_600</item>
 
         <!-- Background color - Pure white -->
         <item name="android:colorBackground">@color/white</item>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.kapt) apply false
-    id("com.autonomousapps.dependency-analysis") version "3.4.1"
+    id("com.autonomousapps.dependency-analysis") version "3.5.1"
+    id("com.google.android.gms.oss-licenses-plugin") version "0.10.10" apply false
 }


### PR DESCRIPTION
This commit introduces several UI enhancements and dependency updates.

Key changes:
- Increases the contrast of the on-surface variant color for better legibility by changing it from `grey_500` to `grey_600`.
- Replaces theme-aware icon colors (`?attr/colorControlNormal`) with a fixed `darker_gray` for settings icons (`ic_backup`, `ic_display`, `ic_info`, `ic_security`) to ensure consistent visibility.
- Updates the password generator dialog by setting a title, improving layout padding, and establishing a minimum password length of 4.
- Adds an "Open Source Licenses" screen to the settings menu, leveraging the `play-services-oss-licenses` library.
- Updates the dependency analysis plugin to version `3.5.1`.
- Increments the app version to `1.3.0` and `versionCode` to `22`.