### PR TITLE
feat(security): Implement configurable auto-lock timeout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 25
-        versionName = "1.4.1"
+        versionName = "1.5.0-beta1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/jksalcedo/passvault/repositories/PreferenceRepository.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/repositories/PreferenceRepository.kt
@@ -233,6 +233,42 @@ class PreferenceRepository(context: Context) {
     }
 
     /**
+     * Sets the auto-lock timeout in milliseconds.
+     * @param timeout The timeout in milliseconds. -1 for never.
+     */
+    fun setAutoLockTimeout(timeout: Long) {
+        prefs.edit { putString("auto_lock_timeout", timeout.toString()) }
+    }
+
+    /**
+     * Gets the auto-lock timeout in milliseconds.
+     * @return The timeout in milliseconds. Default is 60000 (1 minute).
+     */
+    fun getAutoLockTimeout(): Long {
+        return try {
+            prefs.getString("auto_lock_timeout", "60000")?.toLong() ?: 60000L
+        } catch (e: Exception) {
+            60000L
+        }
+    }
+
+    /**
+     * Sets the last interaction time.
+     * @param time The timestamp in milliseconds.
+     */
+    fun setLastInteractionTime(time: Long) {
+        prefs.edit { putLong("last_interaction_time", time) }
+    }
+
+    /**
+     * Gets the last interaction time.
+     * @return The timestamp in milliseconds.
+     */
+    fun getLastInteractionTime(): Long {
+        return prefs.getLong("last_interaction_time", 0L)
+    }
+
+    /**
      * Clears all preferences.
      */
     fun clear() {

--- a/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsFragment.kt
@@ -493,6 +493,17 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
             true
         }
+
+        setupAutoLockTimeout()
+    }
+
+    private fun setupAutoLockTimeout() {
+        val timeoutPref = findPreference<ListPreference>("auto_lock_timeout")
+        timeoutPref?.setOnPreferenceChangeListener { _, newValue ->
+            val timeout = (newValue as String).toLong()
+            prefsRepository.setAutoLockTimeout(timeout)
+            true
+        }
     }
 
     private val pickBackupLocationLauncher =

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -72,4 +72,24 @@
         <item>system</item>
         <item>en</item>
     </string-array>
+
+    <string-array name="auto_lock_timeout_entries">
+        <item>30 Seconds</item>
+        <item>1 Minute</item>
+        <item>2 Minutes</item>
+        <item>5 Minutes</item>
+        <item>10 Minutes</item>
+        <item>30 Minutes</item>
+        <item>Never</item>
+    </string-array>
+
+    <string-array name="auto_lock_timeout_values">
+        <item>30000</item>
+        <item>60000</item>
+        <item>120000</item>
+        <item>300000</item>
+        <item>600000</item>
+        <item>1800000</item>
+        <item>-1</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/settings_security.xml
+++ b/app/src/main/res/xml/settings_security.xml
@@ -25,6 +25,15 @@
             app:summary="Prevent screenshots and screen recording for enhanced security"
             app:title="Block Screenshots" />
 
+        <ListPreference
+            app:defaultValue="60000"
+            app:entries="@array/auto_lock_timeout_entries"
+            app:entryValues="@array/auto_lock_timeout_values"
+            app:iconSpaceReserved="false"
+            app:key="auto_lock_timeout"
+            app:title="Auto-lock Timeout"
+            app:useSimpleSummaryProvider="true" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/metadata/en-US/changelogs/25.txt
+++ b/metadata/en-US/changelogs/25.txt
@@ -1,3 +1,5 @@
 - Improved search functionality: now searches all fields (Title, Username, Email, URL, Notes)
 - Search now respects the selected category filter
 - Fixed search bar UI issues
+- Added configurable Auto-lock Timeout setting (30s to 30m)
+- Improved auto-lock reliability


### PR DESCRIPTION
This commit introduces a new security feature allowing users to configure the auto-lock timeout for the application. The hardcoded 1-minute timeout has been replaced with a user-configurable setting, enhancing both security and usability.

Key changes:
- **New Setting:**
    - Added an "Auto-lock Timeout" option in the Security settings (`settings_security.xml`).
    - Users can choose from 30 seconds to 30 minutes, or disable it entirely (`arrays.xml`).
- **Preference Handling:**
    - Implemented methods in `PreferenceRepository` to get and set the auto-lock timeout and persist the last user interaction time.
    - `SettingsFragment` now handles changes to the new timeout preference.
- **Improved Auto-Lock Logic:**
    - In `Application.kt`, the auto-lock mechanism now retrieves the timeout value from preferences.
    - Last interaction time is now saved to preferences to ensure auto-lock reliability, even after the app process is killed and restarted.
- **Build & Metadata:**
    - Updated the app version to `1.5.0-beta1`.
    - Added a changelog entry for the new feature (`25.txt`).