### PR TITLE
feat(crash): Implement crash reporting and log sharing

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/repositories/PreferenceRepository.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/repositories/PreferenceRepository.kt
@@ -281,7 +281,8 @@ class PreferenceRepository(context: Context) {
      * @return The format string. Default is "passvault_backup_{timestamp}".
      */
     fun getBackupFileNameFormat(): String {
-        return prefs.getString("backup_filename_format", "passvault_backup_{timestamp}") ?: "passvault_backup_{timestamp}"
+        return prefs.getString("backup_filename_format", "passvault_backup_{timestamp}")
+            ?: "passvault_backup_{timestamp}"
     }
 
     /**
@@ -297,7 +298,8 @@ class PreferenceRepository(context: Context) {
      * @return The format string. Default is "yyyy-MM-dd_HH-mm-ss".
      */
     fun getBackupTimestampFormat(): String {
-        return prefs.getString("backup_timestamp_format", "yyyy-MM-dd_HH-mm-ss") ?: "yyyy-MM-dd_HH-mm-ss"
+        return prefs.getString("backup_timestamp_format", "yyyy-MM-dd_HH-mm-ss")
+            ?: "yyyy-MM-dd_HH-mm-ss"
     }
 
     /**
@@ -305,5 +307,13 @@ class PreferenceRepository(context: Context) {
      */
     fun clear() {
         prefs.edit { clear().apply() }
+    }
+
+    fun setCrashLogsLocation(uri: String?) {
+        prefs.edit { putString("crash_logs_location", uri) }
+    }
+
+    fun getCrashLogsLocation(): String? {
+        return prefs.getString("crash_logs_location", null)
     }
 }

--- a/app/src/main/java/com/jksalcedo/passvault/ui/addedit/AddEditActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/addedit/AddEditActivity.kt
@@ -42,7 +42,7 @@ class AddEditActivity : BaseActivity(), PasswordDialogListener {
 
         // Load categories for dropdown
         categoryViewModel.allCategories.observe(this) { categories ->
-            val categoryNames = categories.map { it.name }
+            val categoryNames = categories.mapNotNull { it.name.takeIf(String::isNotBlank) }
             val adapter =
                 ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, categoryNames)
             binding.etCategory.setAdapter(adapter)
@@ -206,7 +206,11 @@ class AddEditActivity : BaseActivity(), PasswordDialogListener {
         val result = PasswordStrengthAnalyzer.analyze(password)
 
         // Update progress bar
-        binding.progressPasswordStrength.setProgress(result.score, true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            binding.progressPasswordStrength.setProgress(result.score, true)
+        } else {
+            binding.progressPasswordStrength.progress = result.score
+        }
 
         // Update color based on strength level
         val colorResId = when (result.level) {

--- a/app/src/main/java/com/jksalcedo/passvault/utils/PassVaultCrashHandler.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/utils/PassVaultCrashHandler.kt
@@ -1,0 +1,100 @@
+package com.jksalcedo.passvault.utils
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.os.Build
+import android.util.Log
+import androidx.core.net.toUri
+import com.jksalcedo.passvault.repositories.PreferenceRepository
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class PassVaultCrashHandler(
+    private val context: Context,
+    private val preferenceRepository: PreferenceRepository,
+    private val defaultHandler: Thread.UncaughtExceptionHandler?
+) : Thread.UncaughtExceptionHandler {
+
+    companion object {
+        private const val TAG = "PassVaultCrashHandler"
+    }
+
+    override fun uncaughtException(t: Thread, e: Throwable) {
+        try {
+            val timestamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US)
+                .format(Date())
+
+            val packageInfo: PackageInfo = try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    context.packageManager.getPackageInfo(context.packageName, 0)
+                } else {
+                    @Suppress("DEPRECATION")
+                    context.packageManager.getPackageInfo(context.packageName, 0)
+                }
+            } catch (_: Exception) {
+                PackageInfo().apply {
+                    packageName = context.packageName
+                    versionName = "Unknown"
+                }
+            }
+
+            val contentToWrite = """
+                $timestamp
+                ${packageInfo.packageName} ${packageInfo.versionName}
+                ${Build.HOST} ${Build.DEVICE}
+                ${Build.VERSION.BASE_OS}
+                                
+                ${Log.getStackTraceString(e)}
+            """.trimIndent()
+
+            val fileName = "PV_Crash_$timestamp.txt"
+            val crashLocationUri = preferenceRepository.getCrashLogsLocation()
+
+            if (crashLocationUri != null) {
+                // Use custom location (SAF)
+                try {
+                    val treeUri = crashLocationUri.toUri()
+                    val pickedDir = androidx.documentfile.provider.DocumentFile.fromTreeUri(
+                        context,
+                        treeUri
+                    )
+
+                    if (pickedDir != null && pickedDir.canWrite()) {
+                        val newFile = pickedDir.createFile("text/plain", fileName)
+                        if (newFile != null) {
+                            context.contentResolver.openOutputStream(newFile.uri)
+                                ?.use { outputStream ->
+                                    outputStream.write(contentToWrite.toByteArray())
+                                }
+                        } else {
+                            Log.e(TAG, "Failed to create crash log file")
+                        }
+                    } else {
+                        Log.e(TAG, "Custom crash logs location is not accessible or writable")
+                    }
+                } catch (ex: Exception) {
+                    Log.e(TAG, "Error writing crash log to custom location", ex)
+                }
+            } else {
+                // Use default internal storage
+                try {
+                    val crashLogDir = File(context.getExternalFilesDir(null), "crash_logs")
+                    if (!crashLogDir.exists()) {
+                        crashLogDir.mkdirs()
+                    }
+                    val crashLogFile = File(crashLogDir, fileName)
+                    crashLogFile.writeText(contentToWrite)
+                } catch (ex: Exception) {
+                    Log.e(TAG, "Error writing crash log to internal storage", ex)
+                }
+            }
+        } catch (ex: Exception) {
+            Log.e(TAG, "Error in crash handler", ex)
+        } finally {
+            // Always call the default handler to ensure the app crashes properly
+            defaultHandler?.uncaughtException(t, e)
+        }
+    }
+}

--- a/app/src/main/java/com/jksalcedo/passvault/utils/Utility.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/utils/Utility.kt
@@ -212,4 +212,28 @@ object Utility {
         }
         return context.getColor(colorRes)
     }
+    fun zipFiles(files: List<File>, zipFile: File): Boolean {
+        return try {
+            java.util.zip.ZipOutputStream(java.io.BufferedOutputStream(java.io.FileOutputStream(zipFile)))
+                .use { out ->
+                    val data = ByteArray(1024)
+                    for (file in files) {
+                        java.io.FileInputStream(file).use { fi ->
+                            java.io.BufferedInputStream(fi, 1024).use { origin ->
+                                val entry = java.util.zip.ZipEntry(file.name)
+                                out.putNextEntry(entry)
+                                var count: Int
+                                while (origin.read(data, 0, 1024).also { count = it } != -1) {
+                                    out.write(data, 0, count)
+                                }
+                            }
+                        }
+                    }
+                }
+            true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
 }

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -3,4 +3,7 @@
     <external-files-path
         name="my_backups"
         path="backups/" />
+    <cache-path
+        name="cache"
+        path="." />
 </paths>

--- a/app/src/main/res/xml/settings_data_sync.xml
+++ b/app/src/main/res/xml/settings_data_sync.xml
@@ -2,7 +2,13 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
-        app:title="Backup &amp; Restore">
+        app:title="Vault Management">
+
+        <Preference
+            app:iconSpaceReserved="false"
+            app:key="storage_info"
+            app:summary="View database size and entry count"
+            app:title="Storage Information" />
 
         <Preference
             app:iconSpaceReserved="false"
@@ -24,6 +30,18 @@
             app:key="export_format"
             app:title="Export Format"
             app:useSimpleSummaryProvider="true" />
+
+        <Preference
+            app:iconSpaceReserved="false"
+            app:key="clear_data"
+            app:summary="Permanently delete all stored entries"
+            app:title="Clear All Data" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="Backup &amp; Restore">
 
         <SwitchPreferenceCompat
             app:defaultValue="false"
@@ -77,19 +95,19 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
-        app:title="Data Management">
+        app:title="Troubleshooting">
 
         <Preference
             app:iconSpaceReserved="false"
-            app:key="storage_info"
-            app:summary="View database size and entry count"
-            app:title="Storage Information" />
+            app:key="crash_logs_location"
+            app:summary="Default: Internal App Storage"
+            app:title="Crash Logs Location" />
 
         <Preference
             app:iconSpaceReserved="false"
-            app:key="clear_data"
-            app:summary="Permanently delete all stored entries"
-            app:title="Clear All Data" />
+            app:key="share_crash_logs"
+            app:summary="Share all crash logs as a zip file"
+            app:title="Share Crash Logs" />
 
     </PreferenceCategory>
 

--- a/app/src/test/java/com/jksalcedo/passvault/utils/PassVaultCrashHandlerTest.kt
+++ b/app/src/test/java/com/jksalcedo/passvault/utils/PassVaultCrashHandlerTest.kt
@@ -1,0 +1,78 @@
+package com.jksalcedo.passvault.utils
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import com.jksalcedo.passvault.repositories.PreferenceRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.lang.Thread.UncaughtExceptionHandler
+
+class PassVaultCrashHandlerTest {
+
+    private lateinit var context: Context
+    private lateinit var preferenceRepository: PreferenceRepository
+    private lateinit var defaultHandler: UncaughtExceptionHandler
+    private lateinit var crashHandler: PassVaultCrashHandler
+    private lateinit var packageManager: PackageManager
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        preferenceRepository = mockk(relaxed = true)
+        defaultHandler = mockk(relaxed = true)
+        packageManager = mockk(relaxed = true)
+
+        every { context.packageName } returns "com.jksalcedo.passvault"
+        every { context.packageManager } returns packageManager
+
+        // Mock PackageInfo
+        val packageInfo = PackageInfo()
+        packageInfo.packageName = "com.jksalcedo.passvault"
+        packageInfo.versionName = "1.0.0"
+        every { packageManager.getPackageInfo(any<String>(), any<Int>()) } returns packageInfo
+
+        // Mock File operations
+        mockkStatic(File::class)
+
+        crashHandler = PassVaultCrashHandler(context, preferenceRepository, defaultHandler)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `uncaughtException should call default handler`() {
+        val thread = Thread.currentThread()
+        val exception = RuntimeException("Test Exception")
+
+        val mockFile = mockk<File>(relaxed = true)
+        every { context.getExternalFilesDir(any()) } returns mockFile
+        every { mockFile.exists() } returns true
+
+        crashHandler.uncaughtException(thread, exception)
+
+        verify { defaultHandler.uncaughtException(thread, exception) }
+    }
+
+    @Test
+    fun `uncaughtException should handle exceptions during logging and still call default handler`() {
+        val thread = Thread.currentThread()
+        val exception = RuntimeException("Test Exception")
+
+        every { context.packageName } throws RuntimeException("Context Error")
+
+        crashHandler.uncaughtException(thread, exception)
+
+        verify { defaultHandler.uncaughtException(thread, exception) }
+    }
+}


### PR DESCRIPTION
This commit introduces a robust crash reporting system that captures detailed information upon application failure and saves it to a log file. It also provides users with the ability to configure the storage location for these logs and share them for troubleshooting.

### Key Changes:

- **Crash Handler Implementation:**
    - A new `PassVaultCrashHandler` is implemented to catch all uncaught exceptions.
    - On a crash, it generates a detailed report including a timestamp, app version, device info, and the full stack trace.
    - This handler is registered in the `Application` class to ensure it's active throughout the app's lifecycle.

- **Configurable Crash Log Location:**
    - A new "Crash Logs Location" option has been added to the "Troubleshooting" settings (`settings_data_sync.xml`).
    - Users can now select a custom directory to store crash logs using the Storage Access Framework (SAF).
    - If no custom location is set, logs are saved to a `crash_logs` directory within the app's internal storage by default.
    - New methods (`setCrashLogsLocation`, `getCrashLogsLocation`) were added to `PreferenceRepository` to manage this setting.

- **Share Crash Logs Functionality:**
    - A "Share Crash Logs" option is now available, allowing users to easily share all captured crash logs.
    - The feature gathers log files from either the default or custom location, compresses them into a single `.zip` file, and opens a share sheet.
    - A new `zipFiles` utility function was added to `Utility.kt` to handle the file compression.

- **UI and Minor Fixes:**
    - The "Data & Sync" settings screen has been reorganized into "Vault Management" and "Troubleshooting" categories for better clarity.
    - Added a `FileProvider` path for the cache directory to enable sharing of the generated zip file (`provider_paths.xml`).
    - Fixed a potential crash in `AddEditActivity` by filtering out blank category names.
    - Ensured compatibility for setting password strength progress on older Android versions (pre-N) in `AddEditActivity`.