### PR TITLE
Implement custom fields for password entries

### DIFF
--- a/app/schemas/com.jksalcedo.passvault.data.AppDatabase/5.json
+++ b/app/schemas/com.jksalcedo.passvault.data.AppDatabase/5.json
@@ -1,0 +1,132 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "1ae326e23a2f2e1113e3660256c12e60",
+    "entities": [
+      {
+        "tableName": "password_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `username` TEXT, `passwordCipher` TEXT NOT NULL, `passwordIv` TEXT NOT NULL, `notes` TEXT, `email` TEXT, `url` TEXT, `category` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `customFieldsCipher` TEXT, `customFieldsIv` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passwordCipher",
+            "columnName": "passwordCipher",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordIv",
+            "columnName": "passwordIv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customFieldsCipher",
+            "columnName": "customFieldsCipher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customFieldsIv",
+            "columnName": "customFieldsIv",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `colorHex` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "colorHex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1ae326e23a2f2e1113e3660256c12e60')"
+    ]
+  }
+}

--- a/app/src/main/java/com/jksalcedo/passvault/adapter/CustomFieldsAdapter.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/adapter/CustomFieldsAdapter.kt
@@ -1,0 +1,113 @@
+package com.jksalcedo.passvault.adapter
+
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.jksalcedo.passvault.data.CustomField
+import com.jksalcedo.passvault.databinding.ItemCustomFieldBinding
+import java.util.Collections
+
+class CustomFieldsAdapter(
+    private val isReadOnly: Boolean = false,
+    private val onEditClick: ((CustomField) -> Unit)? = null,
+    private val onDeleteClick: ((CustomField) -> Unit)? = null,
+    private val onCopyClick: (CustomField) -> Unit,
+    private val onStartDrag: ((RecyclerView.ViewHolder) -> Unit)? = null
+) : ListAdapter<CustomField, CustomFieldsAdapter.ViewHolder>(CustomFieldDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemCustomFieldBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+
+
+    inner class ViewHolder(private val binding: ItemCustomFieldBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: CustomField) {
+            binding.tvFieldName.text = item.name
+            binding.tvFieldValue.text = if (item.isSecret) "••••••••" else item.value
+
+            binding.btnMenu.visibility = View.VISIBLE
+            
+            if (isReadOnly) {
+                binding.ivDragHandle.visibility = View.GONE
+                
+                binding.btnMenu.setOnClickListener { view ->
+                    val popup = android.widget.PopupMenu(view.context, view)
+                    popup.menu.add(0, 1, 0, "Copy")
+                    
+                    popup.setOnMenuItemClickListener { menuItem ->
+                        if (menuItem.itemId == 1) onCopyClick(item)
+                        true
+                    }
+                    popup.show()
+                }
+            } else {
+                binding.ivDragHandle.visibility = View.VISIBLE
+                
+                binding.btnMenu.setOnClickListener { view ->
+                    val popup = android.widget.PopupMenu(view.context, view)
+                    popup.menu.add(0, 1, 0, "Copy")
+                    popup.menu.add(0, 2, 0, "Edit")
+                    popup.menu.add(0, 3, 0, "Delete")
+                    
+                    popup.setOnMenuItemClickListener { menuItem ->
+                        when (menuItem.itemId) {
+                            1 -> onCopyClick(item)
+                            2 -> onEditClick?.invoke(item)
+                            3 -> onDeleteClick?.invoke(item)
+                        }
+                        true
+                    }
+                    popup.show()
+                }
+
+                binding.ivDragHandle.setOnTouchListener { _, event ->
+                    if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                        onStartDrag?.invoke(this)
+                    }
+                    false
+                }
+            }
+
+            // Toggle visibility on click for secret fields
+            binding.root.setOnClickListener {
+                if (item.isSecret) {
+                    if (binding.tvFieldValue.text == "••••••••") {
+                        binding.tvFieldValue.text = item.value
+                    } else {
+                        binding.tvFieldValue.text = "••••••••"
+                    }
+                } else if (isReadOnly) {
+                     onCopyClick(item)
+                }
+            }
+
+
+        }
+    }
+
+    class CustomFieldDiffCallback : DiffUtil.ItemCallback<CustomField>() {
+        override fun areItemsTheSame(oldItem: CustomField, newItem: CustomField): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: CustomField, newItem: CustomField): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/jksalcedo/passvault/data/AppDatabase.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/AppDatabase.kt
@@ -13,12 +13,13 @@ import com.jksalcedo.passvault.dao.PasswordDao
 
 @Database(
     entities = [PasswordEntry::class, Category::class],
-    version = 4,
+    version = 5,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
-        AutoMigration(from = 3, to = 4, spec = AppDatabase.Migration3To4::class)
+        AutoMigration(from = 3, to = 4, spec = AppDatabase.Migration3To4::class),
+        AutoMigration(from = 4, to = 5)
     ]
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/jksalcedo/passvault/data/CustomFields.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/CustomFields.kt
@@ -1,0 +1,19 @@
+package com.jksalcedo.passvault.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CustomFieldsPayload(
+    val version: Int = 1,
+    val fields: List<CustomField> = emptyList()
+)
+
+@Serializable
+data class CustomField(
+    val id: String,
+    val name: String,
+    val value: String,
+    val isSecret: Boolean = false,
+    val meta: Map<String, String> = emptyMap(),
+    val order: Int = 0
+)

--- a/app/src/main/java/com/jksalcedo/passvault/data/ImportRecord.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/ImportRecord.kt
@@ -12,5 +12,6 @@ data class ImportRecord(
     val category: String? = null,
     val notes: String?,
     val createdAt: Long?,
-    val updatedAt: Long?
+    val updatedAt: Long?,
+    val customFields: List<CustomField> = emptyList()
 )

--- a/app/src/main/java/com/jksalcedo/passvault/data/PasswordEntry.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/data/PasswordEntry.kt
@@ -20,5 +20,7 @@ data class PasswordEntry(
     val url: String? = null,
     val category: String? = "General",
     val createdAt: Long = System.currentTimeMillis(),
-    val updatedAt: Long = System.currentTimeMillis()
+    val updatedAt: Long = System.currentTimeMillis(),
+    val customFieldsCipher: String? = null,
+    val customFieldsIv: String? = null
 ) : Parcelable

--- a/app/src/main/res/drawable/ic_drag_handle.xml
+++ b/app/src/main/res/drawable/ic_drag_handle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,9H4v2h16V9zM4,15h16v-2H4v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_more_vert.xml
+++ b/app/src/main/res/drawable/ic_more_vert.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+</vector>

--- a/app/src/main/res/layout/activity_add_edit.xml
+++ b/app/src/main/res/layout/activity_add_edit.xml
@@ -213,6 +213,7 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginBottom="20dp"
                 android:hint="@string/notes"
                 app:boxCornerRadiusBottomEnd="12dp"
                 app:boxCornerRadiusBottomStart="12dp"
@@ -227,6 +228,39 @@
                     android:minLines="4"
                     android:paddingVertical="16dp" />
             </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Custom Fields Section -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="20dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:text="Custom Fields"
+                    android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_custom_fields"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:nestedScrollingEnabled="false"
+                    tools:itemCount="2"
+                    tools:listitem="@layout/item_custom_field" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_add_custom_field"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start"
+                    android:text="Add Field"
+                    app:icon="@drawable/ic_edit" />
+
+            </LinearLayout>
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_view_entry.xml
+++ b/app/src/main/res/layout/activity_view_entry.xml
@@ -288,6 +288,19 @@
 
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Custom Fields RecyclerView -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_custom_fields"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:nestedScrollingEnabled="false"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/cardUrl"
+                tools:itemCount="2"
+                tools:listitem="@layout/item_custom_field"/>
+
             <!-- Notes Card -->
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/cardNotes"
@@ -298,7 +311,7 @@
                 app:cardElevation="1dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/cardUrl"
+                app:layout_constraintTop_toBottomOf="@id/rv_custom_fields"
                 app:strokeWidth="0dp">
 
                 <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/dialog_add_custom_field.xml
+++ b/app/src/main/res/layout/dialog_add_custom_field.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:hint="@string/field_name">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_field_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textCapWords"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:hint="@string/value">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_field_value"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switch_is_secret"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/secret_masked" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_custom_field.xml
+++ b/app/src/main/res/layout/item_custom_field.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginVertical="4dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="2dp"
+    app:strokeWidth="0dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp">
+
+        <ImageView
+            android:id="@+id/iv_drag_handle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/drag_handle"
+            android:src="@drawable/ic_drag_handle"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/colorControlNormal" />
+
+        <TextView
+            android:id="@+id/tv_field_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="8dp"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@+id/btn_menu"
+            app:layout_constraintStart_toEndOf="@+id/iv_drag_handle"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Security Question" />
+
+        <TextView
+            android:id="@+id/tv_field_value"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="8dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="?attr/textAppearanceBody2"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/btn_menu"
+            app:layout_constraintStart_toEndOf="@+id/iv_drag_handle"
+            app:layout_constraintTop_toBottomOf="@+id/tv_field_name"
+            tools:text="Maiden Name" />
+
+        <ImageButton
+            android:id="@+id/btn_menu"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/options"
+            android:src="@drawable/ic_more_vert"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/colorControlNormal" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,11 @@
     <string name="delete_category">Delete Category</string>
     <string name="import_summary">Import Summary</string>
     <string name="icon">Icon</string>
+    <string name="drag_handle">Drag Handle</string>
+    <string name="field_name">Field Name</string>
+    <string name="value">Value</string>
+    <string name="secret_masked">Secret (Masked)</string>
+    <string name="options">Options</string>
 
     <string-array name="backup_options">
         <item>Restore</item>

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,4 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=true
+org.gradle.java.home=/usr/lib/jvm/jdk-22


### PR DESCRIPTION
This commit introduces the ability to add, edit, and view custom fields for password entries, providing greater flexibility for storing additional information securely.

### Key Changes:

- **Custom Fields Functionality:**
    - Users can now add, edit, reorder, and delete custom fields in the Add/Edit screen.
    - Each custom field consists of a name, a value, and an option to mark it as "secret" (masked by default).
    - A new dialog (`dialog_add_custom_field.xml`) has been created for adding and editing fields.

- **Data Model and Storage:**
    - The `PasswordEntry` data class is updated with `customFieldsCipher` and `customFieldsIv` to store encrypted custom fields.
    - The database schema is upgraded to version 5 to include these new columns.
    - `CustomField` and `CustomFieldsPayload` data classes have been created to structure the custom field data before encryption.

- **UI Implementation:**
    - A `RecyclerView` has been added to both `activity_add_edit.xml` and `activity_view_entry.xml` to display custom fields.
    - A new `CustomFieldsAdapter` manages the display and interaction with custom fields, supporting both read-only and edit modes.
    - Drag-and-drop functionality is implemented in the Add/Edit screen to reorder custom fields.

- **View and Interaction:**
    - In the `ViewEntryActivity`, custom fields are displayed in a read-only list. Users can copy a field's value. Secret fields are masked by default and can be revealed with a tap.
    - The `AddEditActivity` now handles the full lifecycle of creating, loading, and saving encrypted custom fields.

- **Import/Export:**
    - The import/export logic in `Utility.kt` has been updated to include custom fields, ensuring they are correctly processed during data migration.