### PR TITLE
Add option to disable biometric login

### DIFF
--- a/app/src/main/java/com/jksalcedo/passvault/repositories/PreferenceRepository.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/repositories/PreferenceRepository.kt
@@ -223,6 +223,14 @@ class PreferenceRepository(context: Context) {
         return prefs.getBoolean("block_screenshots", true)
     }
 
+    fun setBiometricLoginEnabled(enabled: Boolean) {
+        prefs.edit { putBoolean("biometric_login_enabled", enabled) }
+    }
+
+    fun getBiometricLoginEnabled(): Boolean {
+        return prefs.getBoolean("biometric_login_enabled", true)
+    }
+
     /**
      * Sets the backup location URI string.
      * @param uri The URI string of the backup directory.

--- a/app/src/main/java/com/jksalcedo/passvault/ui/auth/UnlockActivity.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/auth/UnlockActivity.kt
@@ -77,15 +77,17 @@ class UnlockActivity : BaseActivity(), SetPinFragment.OnPinSetListener {
 
             binding.clMain.visibility = View.VISIBLE
             binding.fragmentContainer.visibility = View.GONE
-            biometricAuthenticator.showBiometricPrompt(
-                activity = this,
-                onSuccess = {
-                    navigateToNextScreen()
-                },
-                onFailure = { _, errString ->
-                    Toast.makeText(this, errString, Toast.LENGTH_SHORT).show()
-                }
-            )
+            if (prefsRepository.getBiometricLoginEnabled()) {
+                biometricAuthenticator.showBiometricPrompt(
+                    activity = this,
+                    onSuccess = {
+                        navigateToNextScreen()
+                    },
+                    onFailure = { _, errString ->
+                        Toast.makeText(this, errString, Toast.LENGTH_SHORT).show()
+                    }
+                )
+            }
         }
 
         // Check for lockout
@@ -181,7 +183,7 @@ class UnlockActivity : BaseActivity(), SetPinFragment.OnPinSetListener {
      * @param hasPin True if a PIN has been set, false otherwise.
      */
     private fun setupBiometricIfAvailable(hasPin: Boolean) {
-        if (!hasPin) {
+        if (!hasPin || !prefsRepository.getBiometricLoginEnabled()) {
             binding.btnUseBiometric.visibility = View.GONE
             return
         }

--- a/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/jksalcedo/passvault/ui/settings/SettingsFragment.kt
@@ -636,6 +636,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
 
+        val biometricLoginPref = findPreference<SwitchPreferenceCompat>("biometric_login_enabled")
+        biometricLoginPref?.isChecked = prefsRepository.getBiometricLoginEnabled()
+        biometricLoginPref?.setOnPreferenceChangeListener { _, newValue ->
+            prefsRepository.setBiometricLoginEnabled(newValue as Boolean)
+            true
+        }
+
         setupAutoLockTimeout()
         setupChangePassword()
         setupAutofillPreference()

--- a/app/src/main/res/xml/settings_security.xml
+++ b/app/src/main/res/xml/settings_security.xml
@@ -25,6 +25,13 @@
             app:summary="Prevent screenshots and screen recording for enhanced security"
             app:title="Block Screenshots" />
 
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:iconSpaceReserved="false"
+            app:key="biometric_login_enabled"
+            app:summary="Use biometrics on unlock screen when available"
+            app:title="Enable Biometric Login" />
+
         <Preference
             app:iconSpaceReserved="false"
             app:key="change_master_password"


### PR DESCRIPTION
### Motivation
- Provide users a way to opt out of biometric unlocking by adding a toggle in Security settings as requested.

### Description
- Added `setBiometricLoginEnabled` and `getBiometricLoginEnabled` to `PreferenceRepository` to persist the new setting.
- Added a `SwitchPreferenceCompat` entry `biometric_login_enabled` to `res/xml/settings_security.xml` and wired it in `SettingsFragment` to update the repository.
- Updated `UnlockActivity` to respect the setting by skipping the automatic biometric prompt on startup when disabled and hiding the in-UI `Use biometrics` button via `setupBiometricIfAvailable`.

### Testing
- Attempted to run unit tests with `./gradlew :app:testDebugUnitTest --no-daemon`, but the run failed in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`local.properties`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac472e57e883339fee0610e8dd395e)